### PR TITLE
Fix Imputer

### DIFF
--- a/src/main/java/sklearn/preprocessing/Imputer.java
+++ b/src/main/java/sklearn/preprocessing/Imputer.java
@@ -80,7 +80,7 @@ public class Imputer extends Transformer implements HasNumberOfFeatures {
 	}
 
 	private int[] getStatisticsShape(){
-		return ClassDictUtil.getShape(this, "statistics", 1);
+		return ClassDictUtil.getShape(this, "statistics_", 1);
 	}
 
 	static

--- a/src/test/java/sklearn/preprocessing/ImputerTest.java
+++ b/src/test/java/sklearn/preprocessing/ImputerTest.java
@@ -54,6 +54,8 @@ public class ImputerTest {
 		imputer.put("strategy", "most_frequent");
 		imputer.put("missing_values", "NaN");
 		imputer.put("statistics_", 0);
+                
+                assertEquals(1, imputer.getNumberOfFeatures());
 
 		SkLearnEncoder encoder = new SkLearnEncoder();
 


### PR DESCRIPTION
When calculating the number of features, an exception is raised accessing to a misspelled "statistics" attribute (missing suffix "_").

A sklearn pipeline like this raise the exception during the conversion to pmml

```
pipeline = PMMLPipeline([
    ('imputer', Imputer(missing_values='NaN',  axis=0, copy=False)), 
    ("classifier", GradientBoostingClassifier())
])
pipeline.fit(X, y)
sklearn2pmml(pipeline, "GBC.pmml", with_repr=True)
```

```
java.lang.IllegalArgumentException: The value of the sklearn.preprocessing.imputation.Imputer.statistics attribute (null) is not a supported array type
        at org.jpmml.sklearn.ClassDictUtil.getShape(ClassDictUtil.java:99)
        at org.jpmml.sklearn.ClassDictUtil.getShape(ClassDictUtil.java:76)
        at sklearn.preprocessing.Imputer.getStatisticsShape(Imputer.java:83)
        at sklearn.preprocessing.Imputer.getNumberOfFeatures(Imputer.java:39)
        at sklearn.pipeline.Pipeline.encodeFeatures(Pipeline.java:85)
        at sklearn2pmml.PMMLPipeline.encodePMML(PMMLPipeline.java:122)
        at org.jpmml.sklearn.Main.run(Main.java:144)
        at org.jpmml.sklearn.Main.main(Main.java:93)
```
