### PR TITLE
Free cached NDArrays while processing multi-tree models

### DIFF
--- a/src/main/java/joblib/NDArrayWrapper.java
+++ b/src/main/java/joblib/NDArrayWrapper.java
@@ -67,6 +67,10 @@ public class NDArrayWrapper extends PyClassDict implements HasArray {
 		return this.content;
 	}
 
+	public void freeContent() {
+		this.content = null;
+	}
+
 	private NDArray loadContent(){
 
 		try(InputStream is = getInputStream()){

--- a/src/main/java/sklearn/tree/Tree.java
+++ b/src/main/java/sklearn/tree/Tree.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
+import joblib.NDArrayWrapper;
 import org.jpmml.sklearn.CClassDict;
 
 public class Tree extends CClassDict {
@@ -57,6 +58,14 @@ public class Tree extends CClassDict {
 
 	public int[] getNodeSamples(){
 		return Ints.toArray(getNodeAttribute("n_node_samples"));
+	}
+
+	public void freeResources() {
+		for (Object value: values()) {
+			if (value instanceof NDArrayWrapper) {
+				((NDArrayWrapper)value).freeContent();
+			}
+		}
 	}
 
 	private List<? extends Number> getNodeAttribute(String key){

--- a/src/main/java/sklearn/tree/TreeModelUtil.java
+++ b/src/main/java/sklearn/tree/TreeModelUtil.java
@@ -164,8 +164,9 @@ public class TreeModelUtil {
 			@Override
 			public TreeModel apply(T estimator){
 				Schema treeModelSchema = toTreeModelSchema(estimator.getDataType(), segmentSchema);
-
-				return TreeModelUtil.encodeTreeModel(estimator, predicateManager, miningFunction, treeModelSchema);
+				TreeModel model = TreeModelUtil.encodeTreeModel(estimator, predicateManager, miningFunction, treeModelSchema);
+				estimator.getTree().freeResources();
+				return model;
 			}
 		};
 


### PR DESCRIPTION
When converting a multi-tree model, free each tree's cached NDArrays when we finish processing it. This greatly reduces the intermediate memory use of the PMMLPipeline when the underlying PKL model uses multiple files.

This is a followup of a discussion [on the mailing list](https://groups.google.com/forum/#!topic/jpmml/CS2CynzXtmo).

I'm not sure if this needs similar changes anywhere else in the code, perhaps for other model types.

I'm going to be on vacation next week, so if this PR requires nontrivial changes and you don't want to do them yourself, I won't be able to make them until the week of October 1st, but I will reply here and on the mailing list to any messages.